### PR TITLE
Fix map state to props return object

### DIFF
--- a/src/attributes.ts
+++ b/src/attributes.ts
@@ -42,7 +42,7 @@ export function connect(...repositories: [string, Function][]): <TFunction exten
                 throw new Error(`Repository '${repoInfo[1].name}' not registered in the store. Use storeBuilder.addRepository(repo) to register the repository`);
             newState[repoInfo[0]] = { state: getProperty(state, repoDefinition.attachTo) };
         });
-        return state;
+        return newState;
     }, 
     () => {
         var props = {} as any;


### PR DESCRIPTION
Fix map state to props function in order to return the right state object.
This was causing connecting any repository to have every repository connected. Therefore updates would be happening for changes that should not matter.